### PR TITLE
Migrate GitHub Actions from v3 to v4 per deprecation notice (fixes #113)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,7 +86,7 @@ jobs:
         
       
     - name: Upload CodeQL Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-artifacts
         path: ${{ env.RESULTS_DIR }}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,7 +62,7 @@ SCRUB can also be integrated into the CodeQL GitHub Action to produce SCRUB form
         
       
     - name: Upload CodeQL Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-artifacts
         path: ${{ env.RESULTS_DIR }}


### PR DESCRIPTION
Updated `actions/upload-artifact` from v3 to v4 in both:
  - `.github/workflows/codeql.yml`
  - `docs/installation.md`