### PR TITLE
ci: update GitHub Actions to current major versions

### DIFF
--- a/.github/workflows/anchore-syft.yml
+++ b/.github/workflows/anchore-syft.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Scan the image and upload dependency results
       uses: anchore/sbom-action@v0.14.3      
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         #config-file: ./.github/workflows/codeql/codeql-config.yml
         languages: ${{ matrix.language }}
@@ -64,7 +64,7 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
     
     - name: Post-Process Output
       run: |
@@ -86,7 +86,7 @@ jobs:
         
       
     - name: Upload CodeQL Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: codeql-artifacts
         path: ${{ env.RESULTS_DIR }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies


### PR DESCRIPTION
Resolves #113.

Updates all GitHub Actions used in `.github/workflows/` to their current major versions, addressing the deprecation warnings for v3 and v2 artifact/checkout actions.

| Workflow | Action | Before | After |
|---|---|---|---|
| `python-publish.yml` | `actions/checkout` | `v2` | `v4` |
| `python-publish.yml` | `actions/setup-python` | `v2` | `v5` |
| `codeql.yml` | `actions/checkout` | `v3` | `v4` |
| `codeql.yml` | `github/codeql-action/init` | `v2` | `v3` |
| `codeql.yml` | `github/codeql-action/analyze` | `v2` | `v3` |
| `codeql.yml` | `actions/upload-artifact` | `v3` | `v4` |
| `anchore-syft.yml` | `actions/checkout` | `v3` | `v4` |

No logic changes — purely version bumps to keep CI running after GitHub's v3/v2 deprecation deadline.