### PR TITLE
Fix SARIF output: move rules under driver, fix schema URL

### DIFF
--- a/scrub/tools/parsers/translate_results.py
+++ b/scrub/tools/parsers/translate_results.py
@@ -396,14 +396,14 @@ def create_sarif_output_file(results_list, sarif_version, output_file, source_ro
     rules_list = get_rules_list(results_list)
     sarif_output = {
         'version': sarif_version,
-        '$schema': 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json',
+        '$schema': 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json',
         'runs': [
                    {
                        'tool': {
                            'driver': {
-                               'name': tool_name
-                           },
-                           'rules': []
+                               'name': tool_name,
+                               'rules': []
+                           }
                        },
                        'results': []
                    }
@@ -463,7 +463,7 @@ def create_sarif_output_file(results_list, sarif_version, output_file, source_ro
                         'text': rule
                     }
                 })
-            sarif_output['runs'][0]['tool']['rules'] = sarif_rules
+            sarif_output['runs'][0]['tool']['driver']['rules'] = sarif_rules
             result_item['locations'] = [{
                 'physicalLocation': {
                     'artifactLocation': {


### PR DESCRIPTION
Closes #118

SARIF 2.1.0 schema requires rules under tool.driver, not tool.
Moved it in both the initial skeleton and the 2.1.0 update path.
Also fixed the broken $schema URL (master→main, path changed).