### PR TITLE
Fix #124, preserve file-only SARIF locations

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -53,6 +53,14 @@ An example of a set of two warnings that adhere to this format:
         This use of parameter thread has not been checked.
 
 
+## SARIF locations without line numbers
+
+When a SARIF finding or code-flow step identifies a file without a source line,
+SCRUB retains the file location and represents the unknown line internally as
+zero. SARIF 2.1.0 exports omit the optional region in this case, since
+`region.startLine` must be positive. Known positive line numbers are unchanged.
+
+
 ## List of Output Files
 
 The following section provides a description of the structure of the `.scrub` and `scrub_results` output directories located at `SOURCE_DIR` as specified in the `scrub.cfg` configuration file:

--- a/scrub/tools/parsers/translate_results.py
+++ b/scrub/tools/parsers/translate_results.py
@@ -348,8 +348,8 @@ def parse_sarif(sarif_filename, source_root):
                         if thread_location.get('location').get('message'):
                             code_flow_file = pathlib.Path(thread_location.get('location')
                                                           .get('physicalLocation').get('artifactLocation').get('uri'))
-                            code_flow_line = (thread_location.get('location').get('physicalLocation').get('region')
-                                              .get('startLine'))
+                            code_flow_line = (thread_location.get('location').get('physicalLocation').get('region', {})
+                                              .get('startLine', 0))
                             code_flow_description = thread_location.get('location').get('message').get('text')
                             code_flow.append(create_code_flow(code_flow_file, code_flow_line, code_flow_description))
 
@@ -375,6 +375,13 @@ def parse_sarif(sarif_filename, source_root):
         raise Exception
 
     return results
+
+
+def _sarif_region(line):
+    """Omit unknown source lines; SARIF startLine values must be positive."""
+    if line is None or line <= 0:
+        return {}
+    return {'region': {'startLine': line}}
 
 
 def create_sarif_output_file(results_list, sarif_version, output_file, source_root, tool_name):
@@ -473,9 +480,7 @@ def create_sarif_output_file(results_list, sarif_version, output_file, source_ro
                         'uri': warning_file,
                         'uriBaseId': str(source_root)
                     },
-                    'region': {
-                        'startLine': warning['line']
-                    }
+                    **_sarif_region(warning['line'])
                 }
             }]
 
@@ -509,9 +514,7 @@ def create_sarif_output_file(results_list, sarif_version, output_file, source_ro
                                                 'artifactLocation': {
                                                     'uri': artifact_location
                                                 },
-                                                'region': {
-                                                    'startLine': code_flow_item['line']
-                                                }
+                                                **_sarif_region(code_flow_item['line'])
                                             }
                                         }
                                     }

--- a/tests/test_translate_results.py
+++ b/tests/test_translate_results.py
@@ -1,6 +1,8 @@
 import json
 import pathlib
 
+import pytest
+
 from jsonschema import Draft7Validator
 
 from scrub.tools.parsers import translate_results
@@ -76,3 +78,66 @@ def test_create_sarif_2_1_output_uses_driver_rules_and_preserves_results(tmp_pat
     assert run['results'][0]['message']['text'] == 'first warning'
     assert run['results'][0]['locations'][0]['physicalLocation']['region']['startLine'] == 12
     assert_valid_sarif_2_1(sarif_output)
+
+
+@pytest.mark.parametrize('line', [0, None, -1, 12])
+@pytest.mark.parametrize('with_flow', [False, True])
+def test_sarif_output_omits_unknown_line_regions(tmp_path, line, with_flow):
+    """Unknown lines retain their file location without an invalid startLine."""
+    output_file = tmp_path / 'results.sarif'
+    flow = [translate_results.create_code_flow(tmp_path / 'trace.c', line, 'Trace step')] if with_flow else []
+    warning = translate_results.create_warning(
+        'tool001', tmp_path / 'source.c', line, ['File finding'], 'tool',
+        query='R1', code_flow=flow
+    )
+    translate_results.create_sarif_output_file([warning], '2.1.0', output_file, tmp_path, 'tool')
+    output = json.loads(output_file.read_text())
+    assert_valid_sarif_2_1(output)
+    result = output['runs'][0]['results'][0]
+    locations = [result['locations'][0]['physicalLocation']]
+    if with_flow:
+        locations.append(result['codeFlows'][0]['threadFlows'][0]['locations'][0]['location']['physicalLocation'])
+    for location in locations:
+        assert location['artifactLocation']['uri']
+        if line == 12:
+            assert location['region'] == {'startLine': 12}
+        else:
+            assert 'region' not in location
+
+
+@pytest.mark.parametrize('with_flow', [False, True])
+def test_sarif_file_level_locations_round_trip(tmp_path, with_flow):
+    """Valid SARIF without source regions stays valid through the public translator."""
+    input_file = tmp_path / 'input.sarif'
+    output_file = tmp_path / 'output.sarif'
+    result = {
+        'ruleId': 'R1',
+        'message': {'text': 'File finding'},
+        'locations': [{'physicalLocation': {'artifactLocation': {'uri': 'source.c'}}}],
+    }
+    if with_flow:
+        result['codeFlows'] = [{'threadFlows': [{'locations': [{
+            'location': {
+                'message': {'text': 'Trace step'},
+                'physicalLocation': {'artifactLocation': {'uri': 'trace.c'}},
+            }
+        }]}]}]
+    source = {
+        'version': '2.1.0',
+        'runs': [{'tool': {'driver': {'name': 'tool'}}, 'results': [result]}],
+    }
+    assert_valid_sarif_2_1(source)
+    input_file.write_text(json.dumps(source))
+    assert translate_results.perform_translation(input_file, output_file, tmp_path, 'sarifv2.1.0') == 0
+    output = json.loads(output_file.read_text())
+    assert_valid_sarif_2_1(output)
+    output_result = output['runs'][0]['results'][0]
+    assert output_result['ruleId'] == 'R1'
+    assert output_result['message']['text'] == 'File finding'
+    assert len(output['runs'][0]['results']) == 1
+    assert 'region' not in output_result['locations'][0]['physicalLocation']
+    if with_flow:
+        step = output_result['codeFlows'][0]['threadFlows'][0]['locations'][0]['location']
+        assert step['message']['text'] == 'Trace step'
+        assert step['physicalLocation']['artifactLocation']['uri'].endswith('trace.c')
+        assert 'region' not in step['physicalLocation']


### PR DESCRIPTION
Fixes #124.

Preserve file-level findings and code-flow steps when SARIF provides no source region. Use SCRUB's zero sentinel while parsing, and omit the optional output region for unknown/nonpositive lines instead of emitting schema-invalid `startLine: 0`. Positive source lines remain unchanged.

### Validation

- `pytest tests/test_translate_results.py`: 13 passed, including 10 new cases. Eight new cases failed before the fix.
- Validate input and output against the committed SARIF 2.1.0 schema, including public-translator round trips with file-only findings and trace steps.
- Covers absent, zero, negative and positive internal line values while retaining filenames, messages and rule IDs.
- Pylint error checks and `git diff --check` passed. Output documentation updated.

Tested on macOS arm64 with Python 3.12.11. Licensed analyzer integrations, live SonarQube ingestion, other operating systems and SARIF 2.0.0 were not tested. The existing rules/schema-URL fix in #118/#121 is separate.
